### PR TITLE
feat: provide supabase schema

### DIFF
--- a/database/schema/supabase_schema.sql
+++ b/database/schema/supabase_schema.sql
@@ -1,0 +1,135 @@
+-- Supabase PostgreSQL schema generated from Laravel migrations
+-- Run this script in your Supabase project's SQL editor or psql client.
+
+CREATE TABLE users (
+    id bigserial PRIMARY KEY,
+    name varchar(255) NOT NULL,
+    surname varchar(255) NOT NULL,
+    dni varchar(255) NOT NULL UNIQUE,
+    email varchar(255) NOT NULL UNIQUE,
+    email_verified_at timestamp with time zone,
+    password varchar(255) NOT NULL,
+    phone varchar(255) NOT NULL,
+    role varchar(255),
+    image varchar(255),
+    remember_token varchar(100),
+    created_at timestamp with time zone,
+    updated_at timestamp with time zone
+);
+
+CREATE TABLE password_reset_tokens (
+    email varchar(255) PRIMARY KEY,
+    token varchar(255) NOT NULL,
+    created_at timestamp with time zone
+);
+
+CREATE TABLE sessions (
+    id varchar(255) PRIMARY KEY,
+    user_id bigint REFERENCES users(id) ON DELETE SET NULL,
+    ip_address varchar(45),
+    user_agent text,
+    payload text NOT NULL,
+    last_activity integer NOT NULL
+);
+CREATE INDEX sessions_user_id_index ON sessions (user_id);
+CREATE INDEX sessions_last_activity_index ON sessions (last_activity);
+
+CREATE TABLE cache (
+    key varchar(255) PRIMARY KEY,
+    value text NOT NULL,
+    expiration integer NOT NULL
+);
+
+CREATE TABLE cache_locks (
+    key varchar(255) PRIMARY KEY,
+    owner varchar(255) NOT NULL,
+    expiration integer NOT NULL
+);
+
+CREATE TABLE jobs (
+    id bigserial PRIMARY KEY,
+    queue varchar(255) NOT NULL,
+    payload text NOT NULL,
+    attempts smallint NOT NULL,
+    reserved_at integer,
+    available_at integer NOT NULL,
+    created_at integer NOT NULL
+);
+CREATE INDEX jobs_queue_index ON jobs (queue);
+
+CREATE TABLE job_batches (
+    id varchar(255) PRIMARY KEY,
+    name varchar(255) NOT NULL,
+    total_jobs integer NOT NULL,
+    pending_jobs integer NOT NULL,
+    failed_jobs integer NOT NULL,
+    failed_job_ids text NOT NULL,
+    options text,
+    cancelled_at integer,
+    created_at integer NOT NULL,
+    finished_at integer
+);
+
+CREATE TABLE failed_jobs (
+    id bigserial PRIMARY KEY,
+    uuid varchar(255) NOT NULL UNIQUE,
+    connection text NOT NULL,
+    queue text NOT NULL,
+    payload text NOT NULL,
+    exception text NOT NULL,
+    failed_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE recintos (
+    id bigserial PRIMARY KEY,
+    name varchar(255) NOT NULL,
+    description varchar(255) NOT NULL,
+    ubication varchar(255) NOT NULL,
+    province varchar(255) NOT NULL,
+    postal_code varchar(255) NOT NULL,
+    image varchar(255),
+    state text NOT NULL DEFAULT 'Disponible' CHECK (state IN ('Disponible','No disponible','Bloqueado')),
+    created_at timestamp with time zone,
+    updated_at timestamp with time zone
+);
+
+CREATE TABLE reservas (
+    id bigserial PRIMARY KEY,
+    user_id bigint NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    recinto_id bigint NOT NULL REFERENCES recintos(id) ON DELETE CASCADE,
+    price double precision NOT NULL,
+    start_at timestamp with time zone NOT NULL,
+    end_at timestamp with time zone NOT NULL,
+    status text NOT NULL DEFAULT 'activa' CHECK (status IN ('activa','cancelada')),
+    paid boolean NOT NULL DEFAULT false,
+    observations varchar(255),
+    created_at timestamp with time zone,
+    updated_at timestamp with time zone
+);
+
+CREATE TABLE cursos (
+    id bigserial PRIMARY KEY,
+    name varchar(255) NOT NULL,
+    description varchar(255),
+    location varchar(255),
+    begining_date date,
+    end_date date,
+    price numeric(8,2) NOT NULL DEFAULT 0,
+    state text NOT NULL DEFAULT 'Disponible' CHECK (state IN ('Disponible','No disponible','Cancelado')),
+    capacity integer NOT NULL DEFAULT 0,
+    created_at timestamp with time zone,
+    updated_at timestamp with time zone,
+    image varchar(255)
+);
+
+CREATE TABLE inscripciones (
+    id bigserial PRIMARY KEY,
+    user_id bigint NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    curso_id bigint NOT NULL REFERENCES cursos(id) ON DELETE CASCADE,
+    status text NOT NULL DEFAULT 'activa' CHECK (status IN ('activa','cancelada')),
+    paid boolean NOT NULL DEFAULT false,
+    cancelled_by bigint REFERENCES users(id) ON DELETE SET NULL,
+    created_at timestamp with time zone,
+    updated_at timestamp with time zone
+);
+

--- a/docs/supabase-migration.md
+++ b/docs/supabase-migration.md
@@ -1,0 +1,27 @@
+# Supabase migration guide
+
+The file [`database/schema/supabase_schema.sql`](../database/schema/supabase_schema.sql) contains a PostgreSQL script that recreates the current Laravel schema in a Supabase project. Run it through the Supabase SQL editor or any `psql` connection to apply the schema.
+
+## Type equivalences
+
+| Laravel schema builder | PostgreSQL in Supabase | Notes |
+|------------------------|------------------------|-------|
+| `$table->id()` | `bigserial` | Auto‑incrementing primary key |
+| `$table->string()` | `varchar(255)` | Default length used where none specified |
+| `$table->text()`, `$table->mediumText()`, `$table->longText()` | `text` | PostgreSQL uses a single `text` type |
+| `$table->timestamp()` | `timestamp with time zone` | Laravel timestamps map to timestamptz |
+| `$table->boolean()` | `boolean` | |
+| `$table->float('x')` | `double precision` | Used for `reservas.price` |
+| `$table->float('x',8,2)` | `numeric(8,2)` | Used for `cursos.price` |
+| `$table->unsignedTinyInteger()` | `smallint` | Matches 0‑255 range |
+| `$table->enum([...])` | `text` + `CHECK` constraint | Creates explicit allowed values |
+| `$table->rememberToken()` | `varchar(100)` | |
+
+## Notable schema adjustments
+
+- **recintos**: original boolean `state` column replaced with `text` values `('Disponible','No disponible','Bloqueado')` and an optional `image` field.
+- **reservas**: `beggining_date` and `end_date` were replaced by `start_at` and `end_at` timestamps; new `status` (`'activa'`/`'cancelada'`) and `paid` flag added; old boolean `state` removed.
+- **cursos**: price stored as `numeric(8,2)` and state enforced via `CHECK` constraint.
+- **inscripciones**: links users and courses with status and payment flags.
+
+Apply the SQL script after creating a new Supabase project. This will create all required tables and constraints to mirror the Laravel application's structure.


### PR DESCRIPTION
## Summary
- export schema from Laravel migrations into PostgreSQL script for Supabase
- document data type mappings and schema adjustments for Supabase

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68933110a69c832bbb254123ee8617c4