### PR TITLE
chore: add jest and playwright testing setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ yarn-error.log
 /.nova
 /.vscode
 /.zed
+playwright-report
+test-results

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }],
+    ['@babel/preset-react', { runtime: 'automatic' }]
+  ]
+};

--- a/e2e/auth.spec.js
+++ b/e2e/auth.spec.js
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+test('shows login form', async ({ page }) => {
+  await page.goto('http://127.0.0.1:8000/login');
+  await expect(page.getByLabel('Correo electrónico')).toBeVisible();
+});
+
+test('rejects invalid credentials', async ({ page }) => {
+  await page.goto('http://127.0.0.1:8000/login');
+  await page.fill('input[name="email"]', 'wrong@example.com');
+  await page.fill('input[name="password"]', 'invalid');
+  await page.click('button[type="submit"]');
+  await expect(page).toHaveURL('http://127.0.0.1:8000/login');
+});

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  transform: {
+    '^.+\\.[tj]sx?$': 'babel-jest'
+  }
+};

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
     "type": "module",
     "scripts": {
         "build": "vite build",
-        "dev": "vite"
+        "dev": "vite",
+        "test": "jest",
+        "test:e2e": "playwright test"
     },
     "devDependencies": {
         "@popperjs/core": "^2.11.6",
@@ -15,10 +17,19 @@
         "postcss": "^8.4.47",
         "sass": "^1.56.1",
         "tailwindcss": "^3.4.13",
-        "vite": "^6.0.11"
+        "vite": "^6.0.11",
+        "@babel/preset-env": "^7.25.0",
+        "@babel/preset-react": "^7.25.0",
+        "@playwright/test": "^1.45.3",
+        "@testing-library/jest-dom": "^6.4.2",
+        "@testing-library/react": "^14.2.0",
+        "babel-jest": "^29.7.0",
+        "jest": "^29.7.0"
     },
     "dependencies": {
         "bootstrap-icons": "^1.11.3",
-        "bootswatch": "^5.3.3"
+        "bootswatch": "^5.3.3",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
     }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  webServer: {
+    command: 'php artisan serve --host=127.0.0.1 --port=8000',
+    port: 8000,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000
+  }
+});

--- a/resources/js/components/Hello.jsx
+++ b/resources/js/components/Hello.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Hello({ name }) {
+  return <div>Hello {name}</div>;
+}

--- a/resources/js/components/__tests__/Hello.test.jsx
+++ b/resources/js/components/__tests__/Hello.test.jsx
@@ -1,0 +1,7 @@
+import { render, screen } from '@testing-library/react';
+import Hello from '../Hello';
+
+test('renders greeting', () => {
+  render(<Hello name="World" />);
+  expect(screen.getByText('Hello World')).toBeInTheDocument();
+});

--- a/resources/js/utils/__tests__/password.test.js
+++ b/resources/js/utils/__tests__/password.test.js
@@ -1,0 +1,6 @@
+import { toggleType } from '../password';
+
+test('toggleType switches password visibility', () => {
+  expect(toggleType('password')).toBe('text');
+  expect(toggleType('text')).toBe('password');
+});

--- a/resources/js/utils/password.js
+++ b/resources/js/utils/password.js
@@ -1,0 +1,3 @@
+export function toggleType(current) {
+  return current === 'password' ? 'text' : 'password';
+}


### PR DESCRIPTION
## Summary
- configure Jest with Testing Library for React components
- add unit tests for component and password toggle logic
- set up Playwright with authentication e2e scenarios

## Testing
- `npm install --no-fund --no-audit` (fails: 403 Forbidden)
- `npm test` (fails: jest: not found)
- `npm run test:e2e` (fails: playwright: not found)


------
https://chatgpt.com/codex/tasks/task_e_689331201c00832b8570c2ddd68164d1